### PR TITLE
Use X11 only as fallback

### DIFF
--- a/com.super_productivity.SuperProductivity.yml
+++ b/com.super_productivity.SuperProductivity.yml
@@ -10,7 +10,7 @@ rename-icon: superproductivity
 finish-args:
   - --device=dri
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --share=network
   # Allow local file attachments


### PR DESCRIPTION
The GNOME Software considers applications requiring x11 as unsafe. There's a way to declare it uses Wayland, but can use x11 as a fallback, on desktop environments where Wayland doesn't run.

It would be great if the flatpak could use `fallback-x11`  instead of `x11` permission.

More info here:
https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/770#note_1136536

copied from https://github.com/flathub/org.gnome.Evolution/issues/49