### PR TITLE
Update Runtime to 25.08

### DIFF
--- a/com.super_productivity.SuperProductivity.yml
+++ b/com.super_productivity.SuperProductivity.yml
@@ -1,9 +1,9 @@
 app-id: com.super_productivity.SuperProductivity
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '24.08'
+base-version: '25.08'
 command: run.sh
 separate-locales: false
 rename-icon: superproductivity
@@ -42,7 +42,7 @@ modules:
       - desktop-file-edit --set-key=Exec --set-value='run.sh %U' ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
 
       # Patch desktop filename in built-in package.json
-      - patch-desktop-filename ${FLATPAK_DEST}/superproductivity/resources/app.asar
+      - patch-electron-desktop-filename ${FLATPAK_DEST}/superproductivity/resources/app.asar
 
       # Install icons
       - mkdir -p ${FLATPAK_DEST}/share/icons


### PR DESCRIPTION
This updates the Runtime to 25.08 and replaces the deprecated `patch-desktop-filename` with the new `patch-electron-desktop-filename`.