### PR TITLE
metainfo: add release notes for 18.4.3, 18.4.4, 18.5.0

### DIFF
--- a/com.super_productivity.SuperProductivity.metainfo.xml
+++ b/com.super_productivity.SuperProductivity.metainfo.xml
@@ -99,14 +99,39 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="v18.5.0" date="2026-05-09">
-      <description></description>
+    <release version="18.5.0" date="2026-05-09">
+      <description>
+        <ul>
+          <li>Focus mode rework with a new interaction model</li>
+          <li>Scheduler view: reference calendar and work-log events, plus week-view scaling</li>
+          <li>Calendar: estimated time included in iCal/ICS planner entries</li>
+          <li>Tasks: Ctrl+Enter and Escape shortcuts for quicker task interactions</li>
+          <li>Settings: precise start-of-day time format</li>
+          <li>New AI Assistant community plugin and updated translations</li>
+        </ul>
+      </description>
     </release>
     <release version="18.4.4" date="2026-05-02">
-      <description/>
+      <description>
+        <ul>
+          <li>Sections: drag-drop now places tasks at the correct slot</li>
+          <li>Sections: controls hidden until hover on non-touch devices</li>
+          <li>Tasks: focus moves to the next task after moving one to another project</li>
+          <li>Tasks: long unbreakable words in titles now wrap correctly</li>
+        </ul>
+      </description>
     </release>
     <release version="18.4.3" date="2026-05-01">
-      <description/>
+      <description>
+        <ul>
+          <li>CalDAV: import subtasks</li>
+          <li>Recurring tasks: Nth weekday of month (e.g. first Monday)</li>
+          <li>Task widget: per-instance settings with Mac drag and resize fixes</li>
+          <li>Move-to-project menu shows project icons; tag chips render colored dots</li>
+          <li>Planner: faster auto-scroll while dragging tasks</li>
+          <li>Focus mode and sync stability improvements</li>
+        </ul>
+      </description>
     </release>
     <release version="18.3.0" date="2026-04-25">
       <description>


### PR DESCRIPTION
Follow-up to the metainfo refresh from a couple of weeks ago. The 18.4.3, 18.4.4, and 18.5.0 release entries were added automatically by the deb-update workflow but shipped without `<description>` text, so the Flathub listing currently shows "No changelog provided" for the latest three versions.

This PR fills in user-visible highlights for each, sourced from the upstream commit log and GitHub release notes:

- **18.5.0** — focus mode rework, scheduler/calendar improvements, new task shortcuts, AI Assistant community plugin
- **18.4.4** — sections drag-drop fixes and task focus polish
- **18.4.3** — CalDAV subtask import, Nth-weekday recurrence, task widget per-instance settings, planner auto-scroll

I also dropped the stray `v` prefix from the 18.5.0 entry to keep it consistent with the other entries (same fix that was applied to 18.4.3 in 70a619c).

Validation:
- `xmllint --noout` OK
- `appstreamcli validate --strict --no-net` passes (1 pedantic note inherited from the existing app-id)
