### PR TITLE
Enable Wayland socket so idle detection and native rendering work (same as #112)

### DIFF
--- a/com.super_productivity.SuperProductivity.yml
+++ b/com.super_productivity.SuperProductivity.yml
@@ -10,7 +10,14 @@ rename-icon: superproductivity
 finish-args:
   - --device=dri
   - --share=ipc
-  - --socket=x11
+  # Native Wayland on Wayland sessions (Electron 38.2+ auto-selects it from
+  # XDG_SESSION_TYPE). Also required for idle detection on non-GNOME Wayland
+  # compositors (e.g. Niri, Sway): the bundled wayland-idle-helper talks
+  # ext-idle-notify-v1 directly to the compositor and needs the Wayland
+  # socket mounted in the sandbox.
+  - --socket=wayland
+  # X11 rendering on X11-only hosts
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --share=network
   # Allow local file attachments
@@ -23,8 +30,6 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   # Use same mouse cursors as host, to avoid weird cursor sizing under Wayland with mixed DPI
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
-  # Temporarily disable Wayland detection in Electron 38.2+ until we add --socket=wayland
-  - --unset-env=XDG_SESSION_TYPE
 modules:
   - name: super-productivity
     buildsystem: simple


### PR DESCRIPTION
> [!NOTE]
> After opening this I noticed that #112 by @aripollak already proposes the same socket change and has a green test build. Sorry for the overlap! Treat this PR as a duplicate with extra documentation comments and additional verification data (Niri); I'm happy to close it in favor of #112. The findings below apply to either PR.

## Why

Super Productivity's time tracking depends on idle detection. Since v18.3.0 the app bundles a `wayland-idle-helper` binary that speaks `ext-idle-notify-v1` directly to the compositor. This is the intended idle backend for Wayland compositors that don't offer GNOME's Mutter IdleMonitor (Niri, Sway, Hyprland, and friends). The helper ships in the `.deb` this Flatpak repackages and lands correctly at `/app/superproductivity/wayland-idle-helper`, but without `--socket=wayland` it can never reach the compositor: it exits with `Could not find wayland compositor`, and the app silently degrades to a `powerMonitor` backend that permanently reports `idle=0ms`:

```
🕘 Idle check (idle=0ms, method=powerMonitor, duration=0ms, threshold=60000ms, action=skipped:below-threshold)
```

## What

Exactly the linter-sanctioned pattern, and the same diff as #112: `--socket=wayland` plus `--socket=fallback-x11`, and drop the `--unset-env=XDG_SESSION_TYPE` workaround. Since Electron 38.2 the ozone platform is auto-selected from `XDG_SESSION_TYPE` (see [`ui/linux/display_server_utils.cc`](https://github.com/chromium/chromium/blob/main/ui/linux/display_server_utils.cc)), so the app renders native Wayland on Wayland sessions and X11 elsewhere.

## Verification (Niri, v18.9.1 Flathub build with equivalent overrides)

- `niri msg windows` shows the app as a native Wayland surface with App ID `com.super_productivity.SuperProductivity` (the BaseApp desktop-filename patch works as intended).
- Idle detection log:
  ```
  [info]  (IdleTimeHandler) Selected waylandIdleNotify for idle detection
  🕘 Idle check (idle=0ms, method=waylandIdleNotify, …)
  ```
- The bundled helper run standalone in the sandbox prints `ready`, then `idle`, once the socket is granted. Without it: `Could not find wayland compositor`, exit 1.

This complements @aripollak's GNOME Wayland testing in #112 with a non-GNOME compositor where the D-Bus IdleMonitor fallback doesn't exist, i.e. the case that is fully broken today.
